### PR TITLE
Build PyQt DJ mixer MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,64 @@
-# 3D Viewer Example
+# Local DJ Mixer
 
-This repository provides a basic HTML page that uses the
-[`model-viewer`](https://github.com/google/model-viewer) web component to
-render 3D models.
+A cross-platform desktop DJ mixing toolkit built with PyQt5. The app lets you
+load downloaded tracks, automatically analyze their BPM, audition them, adjust
+crossfade durations, and render the final mix to an audio file.
 
-The page loads a GLB/GLTF file and offers a USDZ fallback for iOS devices.
+## Features
 
-## Usage
+- **Track management** – Add or remove audio files via a table-based GUI.
+- **Automatic BPM detection** – Uses `librosa` to analyze the tempo of each
+  track.
+- **Preview playback** – Audition individual tracks directly from the app via
+  `simpleaudio`.
+- **Crossfade control** – Adjustable transitions (1–30 seconds) between tracks.
+- **Tempo-aware mixing** – Optional tempo matching using `pyrubberband` with a
+  fallback resampling approach when the library is unavailable.
+- **Export** – Render and export the mixed result to `.mp3` or `.wav` using
+  `pydub`/`ffmpeg`.
 
-1. Place your `model.glb` (or `.gltf`) and optional `model.usdz` file next to
-   `index.html`.
-2. Open `index.html` in a web browser. Compatible browsers will display the
-   model, and iOS devices will automatically use the USDZ file for AR Quick
-   Look.
+## Getting Started
 
-Feel free to replace the file paths in `index.html` with your own models.
+1. Create and activate a virtual environment.
+2. Install system dependencies:
+   - **FFmpeg** (required by `pydub` for decoding/encoding most formats).
+   - **Rubber Band Library** (optional, enables high-quality time stretching via
+     `pyrubberband`).
+3. Install Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Launch the application:
+
+   ```bash
+   python main.py
+   ```
+
+## Usage Tips
+
+- Use the **Add Tracks** button to queue multiple audio files. BPM analysis
+  runs automatically in the background.
+- Select a track and click **Preview** to audition it. Use **Stop Preview** to
+  halt playback.
+- Drag the crossfade slider to configure how long transitions last between
+  tracks.
+- Click **Render Mix** to export a combined track. Choose `.mp3` or `.wav` in
+  the save dialog.
+- Tempo matching is applied automatically when BPM information is available for
+  consecutive tracks.
+
+## Troubleshooting
+
+- If BPM detection fails, verify that `librosa` is installed and the audio file
+  is readable.
+- Preview playback requires `simpleaudio`. Install platform-specific
+  dependencies as needed (e.g., `portaudio` on some Linux distributions).
+- When `pyrubberband` is unavailable, the mixer falls back to basic resampling.
+  Install the Rubber Band CLI for higher-fidelity stretching.
+
+## Roadmap
+
+Planned enhancements include waveform visualization, drag-and-drop support,
+per-track cueing, and offline rendering progress feedback.

--- a/dj_mixer/__init__.py
+++ b/dj_mixer/__init__.py
@@ -1,0 +1,13 @@
+"""PyQt-based DJ mixing toolkit."""
+
+from .track import Track
+from .bpm import BPMAnalyzer
+from .mixdown import MixdownEngine
+from .playback import PreviewPlayer
+
+__all__ = [
+    "Track",
+    "BPMAnalyzer",
+    "MixdownEngine",
+    "PreviewPlayer",
+]

--- a/dj_mixer/app.py
+++ b/dj_mixer/app.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from PyQt5 import QtCore, QtWidgets
+
+from .bpm import BPMAnalyzer
+from .mixdown import MixdownEngine
+from .playback import PreviewPlayer
+from .track import Track
+
+logger = logging.getLogger(__name__)
+
+
+class BPMWorker(QtCore.QThread):
+    bpmReady = QtCore.pyqtSignal(str, float)
+    failed = QtCore.pyqtSignal(str, str)
+
+    def __init__(self, analyzer: BPMAnalyzer, track: Track) -> None:
+        super().__init__()
+        self.analyzer = analyzer
+        self.track = track
+
+    def run(self) -> None:  # pragma: no cover - requires GUI runtime
+        try:
+            result = self.analyzer.detect(self.track.path)
+        except Exception as exc:  # pragma: no cover
+            logger.exception("BPM detection failed for %s", self.track.path)
+            self.failed.emit(str(self.track.path), str(exc))
+            return
+        self.bpmReady.emit(str(result.path), float(result.bpm))
+
+
+class MixWorker(QtCore.QThread):
+    finishedMix = QtCore.pyqtSignal(object)
+    failed = QtCore.pyqtSignal(str)
+
+    def __init__(self, engine: MixdownEngine, tracks: List[Track], output_path: Optional[str]) -> None:
+        super().__init__()
+        self.engine = engine
+        self.tracks = tracks
+        self.output_path = output_path
+
+    def run(self) -> None:  # pragma: no cover - requires GUI runtime
+        try:
+            result = self.engine.render(self.tracks, self.output_path)
+        except Exception as exc:  # pragma: no cover
+            logger.exception("Failed to render mix")
+            self.failed.emit(str(exc))
+            return
+        self.finishedMix.emit(result)
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Local DJ Mixer")
+        self.resize(900, 600)
+
+        self.tracks: List[Track] = []
+        self.bpm_analyzer: Optional[BPMAnalyzer] = None
+        self.preview_player: Optional[PreviewPlayer] = None
+        self._bpm_workers: List[BPMWorker] = []
+        self._mix_worker: Optional[MixWorker] = None
+
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+
+        self.table = QtWidgets.QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["Title", "BPM", "Duration", "Path"])
+        self.table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        for i in range(1, 4):
+            self.table.horizontalHeader().setSectionResizeMode(i, QtWidgets.QHeaderView.ResizeToContents)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+
+        add_button = QtWidgets.QPushButton("Add Tracks")
+        remove_button = QtWidgets.QPushButton("Remove Selected")
+        preview_button = QtWidgets.QPushButton("Preview")
+        stop_preview_button = QtWidgets.QPushButton("Stop Preview")
+
+        crossfade_label = QtWidgets.QLabel("Crossfade (seconds):")
+        self.crossfade_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.crossfade_slider.setMinimum(1)
+        self.crossfade_slider.setMaximum(30)
+        self.crossfade_slider.setValue(10)
+        self.crossfade_value = QtWidgets.QLabel("10")
+
+        self.mix_button = QtWidgets.QPushButton("Render Mix")
+
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addWidget(self.table)
+
+        controls_layout = QtWidgets.QHBoxLayout()
+        controls_layout.addWidget(add_button)
+        controls_layout.addWidget(remove_button)
+        controls_layout.addWidget(preview_button)
+        controls_layout.addWidget(stop_preview_button)
+        controls_layout.addStretch()
+        layout.addLayout(controls_layout)
+
+        crossfade_layout = QtWidgets.QHBoxLayout()
+        crossfade_layout.addWidget(crossfade_label)
+        crossfade_layout.addWidget(self.crossfade_slider)
+        crossfade_layout.addWidget(self.crossfade_value)
+        layout.addLayout(crossfade_layout)
+
+        layout.addWidget(self.mix_button)
+
+        add_button.clicked.connect(self.add_tracks)
+        remove_button.clicked.connect(self.remove_selected_tracks)
+        preview_button.clicked.connect(self.preview_selected_track)
+        stop_preview_button.clicked.connect(self.stop_preview)
+        self.crossfade_slider.valueChanged.connect(self.update_crossfade_label)
+        self.mix_button.clicked.connect(self.render_mix)
+
+    def ensure_dependencies(self) -> None:
+        if self.bpm_analyzer is None:
+            self.bpm_analyzer = BPMAnalyzer()
+        if self.preview_player is None:
+            self.preview_player = PreviewPlayer()
+
+    def add_tracks(self) -> None:
+        files, _ = QtWidgets.QFileDialog.getOpenFileNames(
+            self,
+            "Select audio files",
+            str(Path.home()),
+            "Audio Files (*.mp3 *.wav *.flac *.ogg *.m4a)"
+        )
+        if not files:
+            return
+        self.ensure_dependencies()
+        for file in files:
+            try:
+                track = Track.from_file(file)
+            except Exception as exc:
+                QtWidgets.QMessageBox.critical(self, "Error", f"Failed to load {file}: {exc}")
+                continue
+            self.tracks.append(track)
+            self._append_track_to_table(track)
+            self._run_bpm_detection(track)
+
+    def remove_selected_tracks(self) -> None:
+        selected_rows = sorted({index.row() for index in self.table.selectedIndexes()}, reverse=True)
+        for row in selected_rows:
+            self.table.removeRow(row)
+            del self.tracks[row]
+
+    def _append_track_to_table(self, track: Track) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(track.title))
+        bpm_item = QtWidgets.QTableWidgetItem("…")
+        bpm_item.setTextAlignment(QtCore.Qt.AlignCenter)
+        self.table.setItem(row, 1, bpm_item)
+        self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(track.formatted_duration()))
+        path_item = QtWidgets.QTableWidgetItem(str(track.path))
+        path_item.setToolTip(str(track.path))
+        self.table.setItem(row, 3, path_item)
+
+    def _run_bpm_detection(self, track: Track) -> None:
+        if self.bpm_analyzer is None:
+            return
+        worker = BPMWorker(self.bpm_analyzer, track)
+        worker.bpmReady.connect(self._handle_bpm_ready)
+        worker.failed.connect(self._handle_bpm_failed)
+        worker.start()
+        self._bpm_workers.append(worker)
+
+    @QtCore.pyqtSlot(str, float)
+    def _handle_bpm_ready(self, path: str, bpm: float) -> None:  # pragma: no cover - GUI slot
+        for index, track in enumerate(self.tracks):
+            if str(track.path) == path:
+                track.set_bpm(bpm)
+                item = self.table.item(index, 1)
+                if item:
+                    item.setText(f"{bpm:.2f}")
+                break
+
+    @QtCore.pyqtSlot(str, str)
+    def _handle_bpm_failed(self, path: str, error: str) -> None:  # pragma: no cover - GUI slot
+        QtWidgets.QMessageBox.warning(
+            self,
+            "BPM Detection Failed",
+            f"Could not analyze BPM for {path}: {error}"
+        )
+
+    def preview_selected_track(self) -> None:
+        if self.preview_player is None:
+            try:
+                self.preview_player = PreviewPlayer()
+            except Exception as exc:
+                QtWidgets.QMessageBox.critical(self, "Preview unavailable", str(exc))
+                return
+        rows = {index.row() for index in self.table.selectedIndexes()}
+        if not rows:
+            QtWidgets.QMessageBox.information(self, "Select a track", "Choose a track to preview")
+            return
+        row = rows.pop()
+        track = self.tracks[row]
+        if track.audio is None:
+            QtWidgets.QMessageBox.warning(self, "No audio", "Track audio has not been loaded")
+            return
+        self.preview_player.play(track.audio)
+
+    def stop_preview(self) -> None:
+        if self.preview_player:
+            self.preview_player.stop()
+
+    def update_crossfade_label(self, value: int) -> None:
+        self.crossfade_value.setText(str(value))
+
+    def render_mix(self) -> None:
+        if not self.tracks:
+            QtWidgets.QMessageBox.information(self, "No tracks", "Add tracks before mixing")
+            return
+        output_path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export Mix",
+            str(Path.home() / "mix.mp3"),
+            "Audio Files (*.mp3 *.wav)"
+        )
+        if not output_path:
+            return
+        engine = MixdownEngine(
+            crossfade_seconds=float(self.crossfade_slider.value()),
+            tempo_matching=True,
+        )
+        self._mix_worker = MixWorker(engine, list(self.tracks), output_path)
+        self._mix_worker.finishedMix.connect(self._handle_mix_ready)
+        self._mix_worker.failed.connect(self._handle_mix_failed)
+        self._mix_worker.start()
+        self.mix_button.setEnabled(False)
+        self.mix_button.setText("Mixing…")
+
+    @QtCore.pyqtSlot(object)
+    def _handle_mix_ready(self, result) -> None:  # pragma: no cover - GUI slot
+        self.mix_button.setEnabled(True)
+        self.mix_button.setText("Render Mix")
+        if result.output_path:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Mix ready",
+                f"Mix exported to {result.output_path}"
+            )
+
+    @QtCore.pyqtSlot(str)
+    def _handle_mix_failed(self, error: str) -> None:  # pragma: no cover - GUI slot
+        self.mix_button.setEnabled(True)
+        self.mix_button.setText("Render Mix")
+        QtWidgets.QMessageBox.critical(self, "Mix failed", error)
+
+
+def run() -> None:
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())

--- a/dj_mixer/bpm.py
+++ b/dj_mixer/bpm.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+
+try:
+    import librosa
+except Exception as exc:  # pragma: no cover - handled gracefully at runtime
+    librosa = None
+    _LIBROSA_ERROR = exc
+else:
+    _LIBROSA_ERROR = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BPMResult:
+    path: Path
+    bpm: float
+
+
+class BPMAnalyzer:
+    """Analyze BPM values for tracks using librosa."""
+
+    def __init__(self, hop_length: int = 512) -> None:
+        if librosa is None:
+            raise RuntimeError(
+                "librosa could not be imported. Install it to enable BPM detection"
+            ) from _LIBROSA_ERROR
+        self.hop_length = hop_length
+
+    def detect(self, audio_path: str | Path) -> BPMResult:
+        path = Path(audio_path)
+        if not path.exists():
+            raise FileNotFoundError(path)
+        logger.info("Loading audio for BPM detection: %s", path)
+        y, sr = librosa.load(path.as_posix(), mono=True)
+        tempo, beats = librosa.beat.beat_track(y=y, sr=sr, hop_length=self.hop_length)
+        if tempo is None or np.isnan(tempo):
+            raise ValueError(f"Unable to detect BPM for {path}")
+        return BPMResult(path=path, bpm=float(tempo))
+
+    def bulk_detect(self, paths: Iterable[str | Path]) -> list[BPMResult]:
+        return [self.detect(path) for path in paths]
+
+
+def safe_detect(analyzer: BPMAnalyzer, track: "Track") -> Optional[BPMResult]:
+    from .track import Track  # Local import to avoid circular dependency
+
+    if track.audio is None:
+        return None
+    try:
+        return analyzer.detect(track.path)
+    except Exception:  # pragma: no cover - fallback path
+        logger.exception("Failed to detect BPM for track: %s", track.path)
+        return None

--- a/dj_mixer/mixdown.py
+++ b/dj_mixer/mixdown.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+from pydub import AudioSegment
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import pyrubberband as pyrb
+except Exception:  # pragma: no cover - optional dependency
+    pyrb = None
+
+
+@dataclass
+class MixResult:
+    audio: AudioSegment
+    output_path: Optional[Path] = None
+
+
+class MixdownEngine:
+    """Combine audio tracks with crossfading and optional tempo matching."""
+
+    def __init__(self, crossfade_seconds: float = 10.0, tempo_matching: bool = True) -> None:
+        self.crossfade_seconds = crossfade_seconds
+        self.tempo_matching = tempo_matching
+
+    @property
+    def crossfade_ms(self) -> int:
+        return int(self.crossfade_seconds * 1000)
+
+    def render(self, tracks: Iterable["Track"], output_path: Optional[str | Path] = None) -> MixResult:
+        from .track import Track  # local import to avoid circular dependency
+
+        tracks = [track for track in tracks if track.audio is not None]
+        if not tracks:
+            raise ValueError("No tracks loaded")
+
+        mixed = tracks[0].audio
+        previous_bpm = tracks[0].bpm
+        for track in tracks[1:]:
+            segment = track.audio
+            if self.tempo_matching and previous_bpm and track.bpm:
+                segment = self._match_tempo(segment, track.bpm, previous_bpm)
+            mixed = mixed.append(segment, crossfade=self.crossfade_ms)
+            previous_bpm = track.bpm
+
+        result = MixResult(audio=mixed)
+        if output_path:
+            path = Path(output_path).expanduser().resolve()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            format_ = path.suffix.lstrip(".") or "mp3"
+            logger.info("Exporting final mix to %s", path)
+            mixed.export(path.as_posix(), format=format_)
+            result.output_path = path
+        return result
+
+    def _match_tempo(self, segment: AudioSegment, original_bpm: float, target_bpm: float) -> AudioSegment:
+        if original_bpm <= 0 or target_bpm <= 0:
+            return segment
+        ratio = target_bpm / original_bpm
+        if abs(ratio - 1.0) < 0.02:
+            return segment
+        logger.info("Time stretching track by ratio %.3f", ratio)
+        if pyrb is not None:
+            sample_width = segment.sample_width
+            max_val = float(2 ** (8 * sample_width - 1))
+            target_width = sample_width if sample_width in (2, 4) else 2
+            target_max = float(2 ** (8 * target_width - 1))
+            samples = np.array(segment.get_array_of_samples())
+            if segment.channels > 1:
+                samples = samples.reshape((-1, segment.channels)).T
+            else:
+                samples = samples.reshape((1, -1))
+            normalized = samples.astype(np.float32) / max_val
+            stretched = pyrb.time_stretch(normalized, segment.frame_rate, ratio)
+            stretched = np.clip(stretched, -1.0, 1.0)
+            dtype = np.int16 if target_width == 2 else np.int32
+            scaled = (stretched * target_max).astype(dtype)
+            if segment.channels > 1:
+                scaled = scaled.T.reshape(-1)
+            else:
+                scaled = scaled.reshape(-1)
+            raw_data = scaled.tobytes()
+            new_segment = AudioSegment(
+                raw_data,
+                frame_rate=segment.frame_rate,
+                sample_width=target_width,
+                channels=segment.channels,
+            )
+            return new_segment
+        # Fallback to simple resampling via pydub
+        new_frame_rate = int(segment.frame_rate * ratio)
+        stretched = segment._spawn(segment.raw_data, overrides={"frame_rate": new_frame_rate})
+        return stretched.set_frame_rate(segment.frame_rate)
+
+
+def export_mix(tracks: Iterable["Track"], output_path: str | Path, crossfade_seconds: float = 10.0) -> Path:
+    engine = MixdownEngine(crossfade_seconds=crossfade_seconds)
+    result = engine.render(tracks, output_path=output_path)
+    if result.output_path is None:
+        raise RuntimeError("Failed to export mix")
+    return result.output_path

--- a/dj_mixer/playback.py
+++ b/dj_mixer/playback.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from pydub import AudioSegment
+
+try:  # pragma: no cover - optional dependency
+    import simpleaudio
+except Exception as exc:  # pragma: no cover - runtime feedback
+    simpleaudio = None
+    _SIMPLEAUDIO_ERROR = exc
+else:
+    _SIMPLEAUDIO_ERROR = None
+
+
+class PreviewPlayer:
+    """Simple synchronous preview player built on top of simpleaudio."""
+
+    def __init__(self) -> None:
+        if simpleaudio is None:
+            raise RuntimeError(
+                "simpleaudio could not be imported. Install it to enable previews"
+            ) from _SIMPLEAUDIO_ERROR
+        self._play_obj: Optional[simpleaudio.PlayObject] = None
+        self._lock = threading.Lock()
+
+    def play(self, segment: AudioSegment) -> None:
+        with self._lock:
+            self.stop()
+            data = segment.set_channels(2).set_frame_rate(44100).set_sample_width(2)
+            play_obj = simpleaudio.play_buffer(
+                data.raw_data,
+                num_channels=data.channels,
+                bytes_per_sample=data.sample_width,
+                sample_rate=data.frame_rate,
+            )
+            self._play_obj = play_obj
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._play_obj is not None:
+                self._play_obj.stop()
+                self._play_obj = None
+
+    def is_playing(self) -> bool:
+        with self._lock:
+            return bool(self._play_obj and self._play_obj.is_playing())

--- a/dj_mixer/track.py
+++ b/dj_mixer/track.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from pydub import AudioSegment
+
+
+@dataclass
+class Track:
+    """Container that stores metadata and audio data for a track."""
+
+    path: Path
+    title: str
+    bpm: Optional[float] = None
+    audio: Optional[AudioSegment] = field(default=None, repr=False)
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> "Track":
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(path)
+        title = path.stem
+        audio = AudioSegment.from_file(path)
+        return cls(path=path, title=title, audio=audio)
+
+    @property
+    def duration_seconds(self) -> float:
+        if self.audio is None:
+            return 0.0
+        return self.audio.duration_seconds
+
+    def set_bpm(self, bpm: float) -> None:
+        self.bpm = float(bpm)
+
+    def formatted_duration(self) -> str:
+        total_seconds = int(self.duration_seconds)
+        minutes, seconds = divmod(total_seconds, 60)
+        return f"{minutes}:{seconds:02d}"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from dj_mixer.app import run
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+PyQt5>=5.15
+librosa>=0.9
+pydub>=0.25
+simpleaudio>=1.0
+pyrubberband>=0.3
+soundfile>=0.12
+numpy>=1.21


### PR DESCRIPTION
## Summary
- replace the sample 3D viewer docs with instructions for a cross-platform PyQt DJ mixer
- add a dj_mixer package that loads tracks, detects BPM, previews audio, and renders mixes
- wire up a PyQt5 GUI with crossfade control, background BPM analysis, preview playback, and export support
- document runtime dependencies and entry point for running the mixer

## Testing
- python -m compileall dj_mixer main.py

------
https://chatgpt.com/codex/tasks/task_e_684d92cfe9088331835ed8ab52f7c836